### PR TITLE
Fix double picture bug (#41)

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -34,7 +34,7 @@
 
 - name: Chris Reidy
   affiliation: Research Technologies, UArizona
-  # github:
+  github: resbazaz
   headshot:
   bio:
 
@@ -58,19 +58,19 @@
 
 - name: Tina Johnson
   affiliation: Data Science Institute, UArizona
-  # github:
+  github: resbazaz
   headshot:
   bio:
 
 - name: Jaime Yazzie
   affiliation: Laboratory of Tree Ring Research, UArizona
-  # github:
+  github: resbazaz
   headshot: jaimeyazzie.jpg
   bio:
 
 - name: Valeria Pfeifer
   affiliation: Department of Psychology, UArizona
-  # github:
+  github: resbazaz
   headshot: valeriapfeifer.jpg
   bio:
 

--- a/_data/members.yml
+++ b/_data/members.yml
@@ -34,7 +34,7 @@
 
 - name: Chris Reidy
   affiliation: Research Technologies, UArizona
-  github:
+  # github:
   headshot:
   bio:
 
@@ -58,19 +58,19 @@
 
 - name: Tina Johnson
   affiliation: Data Science Institute, UArizona
-  github:
+  # github:
   headshot:
   bio:
 
 - name: Jaime Yazzie
   affiliation: Laboratory of Tree Ring Research, UArizona
-  github:
+  # github:
   headshot: jaimeyazzie.jpg
   bio:
 
 - name: Valeria Pfeifer
   affiliation: Department of Psychology, UArizona
-  github:
+  # github:
   headshot: valeriapfeifer.jpg
   bio:
 


### PR DESCRIPTION
Fix for #41.  The double-picture bug was only happening for people who didn't have a github account.  I tried just commenting out that yaml field, but that didn't work, so I set the github account to resbazaz for anyone who doesn't have a personal resbaz account.  Open to better solutions.